### PR TITLE
Fixed "check" stuck call.

### DIFF
--- a/resources/js/Components/GeofenceToggle.tsx
+++ b/resources/js/Components/GeofenceToggle.tsx
@@ -3,16 +3,15 @@ import { useState } from 'react';
 
 interface GeofenceToggleProps {
     geofenceId: number;
-    initialActive: boolean;
-    onToggle?: (isActive: boolean) => void;
+    isActive: boolean;
+    onToggled?: (isActive: boolean) => void;
 }
 
 export default function GeofenceToggle({
     geofenceId,
-    initialActive,
-    onToggle,
+    isActive,
+    onToggled,
 }: GeofenceToggleProps) {
-    const [isActive, setIsActive] = useState(initialActive);
     const [loading, setLoading] = useState(false);
     const [locationError, setLocationError] = useState<string | null>(null);
 
@@ -70,9 +69,7 @@ export default function GeofenceToggle({
             const response = await axios.post(
                 `/geo-fences/${geofenceId}/toggle`,
             );
-            const newState = response.data.is_active;
-            setIsActive(newState);
-            onToggle?.(newState);
+            onToggled?.(response.data.is_active);
         } catch {
             // revert on failure
         } finally {

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -24,7 +24,7 @@ export default function Dashboard({ devices, geofence }: DashboardProps) {
     const streamRef = useRef<StreamViewHandle>(null);
     const wasStreamingRef = useRef(false);
 
-    const { tracking, startTracking, stopTracking } = useGeolocation({
+    const { tracking } = useGeolocation({
         geofenceId: geofence?.id ?? 0,
         isActive: geofence?.is_active ?? false,
         onTriggered: () => router.reload(),
@@ -131,11 +131,8 @@ export default function Dashboard({ devices, geofence }: DashboardProps) {
                                     <div className="flex items-center justify-between p-6">
                                         <GeofenceToggle
                                             geofenceId={geofence.id}
-                                            initialActive={geofence.is_active}
-                                            onToggle={(active) => {
-                                                if (active) startTracking();
-                                                else stopTracking();
-                                            }}
+                                            isActive={geofence.is_active}
+                                            onToggled={() => router.reload()}
                                         />
                                         {tracking && (
                                             <span className="text-xs text-green-600">

--- a/resources/js/Pages/Geofence/Index.tsx
+++ b/resources/js/Pages/Geofence/Index.tsx
@@ -36,12 +36,11 @@ export default function Index({ geofence }: GeofencePageProps) {
         router.reload();
     }, []);
 
-    const { tracking, position, startTracking, stopTracking, error } =
-        useGeolocation({
-            geofenceId: geofence?.id ?? 0,
-            isActive: geofence?.is_active ?? false,
-            onTriggered: handleTriggered,
-        });
+    const { tracking, position, error } = useGeolocation({
+        geofenceId: geofence?.id ?? 0,
+        isActive: geofence?.is_active ?? false,
+        onTriggered: handleTriggered,
+    });
 
     const handleAddressSelect = (lat: number, lng: number) => {
         setCenter([lat, lng]);
@@ -119,14 +118,10 @@ export default function Index({ geofence }: GeofencePageProps) {
                                             {geofence && (
                                                 <GeofenceToggle
                                                     geofenceId={geofence.id}
-                                                    initialActive={
-                                                        geofence.is_active
+                                                    isActive={geofence.is_active}
+                                                    onToggled={() =>
+                                                        router.reload()
                                                     }
-                                                    onToggle={(active) => {
-                                                        if (active)
-                                                            startTracking();
-                                                        else stopTracking();
-                                                    }}
                                                 />
                                             )}
                                             {tracking && (

--- a/resources/js/hooks/useGeolocation.ts
+++ b/resources/js/hooks/useGeolocation.ts
@@ -17,11 +17,22 @@ export default function useGeolocation({
     isActive,
     onTriggered,
 }: UseGeolocationOptions) {
-    const [tracking, setTracking] = useState(false);
     const [position, setPosition] = useState<[number, number] | null>(null);
     const [error, setError] = useState<string | null>(null);
     const intervalRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const currentInterval = useRef(FAR_INTERVAL);
+    const onTriggeredRef = useRef(onTriggered);
+
+    useEffect(() => {
+        onTriggeredRef.current = onTriggered;
+    }, [onTriggered]);
+
+    const clearPolling = useCallback(() => {
+        if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+        }
+    }, []);
 
     const checkPosition = useCallback(
         async (pos: GeolocationPosition) => {
@@ -36,8 +47,8 @@ export default function useGeolocation({
                 );
 
                 if (response.data.triggered) {
-                    setTracking(false);
-                    onTriggered();
+                    clearPolling();
+                    onTriggeredRef.current();
                     return;
                 }
 
@@ -52,7 +63,7 @@ export default function useGeolocation({
                 setError('Failed to check position');
             }
         },
-        [geofenceId, onTriggered],
+        [geofenceId, clearPolling],
     );
 
     const poll = useCallback(() => {
@@ -68,11 +79,8 @@ export default function useGeolocation({
     }, [checkPosition]);
 
     useEffect(() => {
-        if (!tracking) {
-            if (intervalRef.current) {
-                clearInterval(intervalRef.current);
-                intervalRef.current = null;
-            }
+        if (!isActive) {
+            clearPolling();
             return;
         }
 
@@ -87,19 +95,12 @@ export default function useGeolocation({
             poll();
         }, currentInterval.current);
 
-        return () => {
-            if (intervalRef.current) {
-                clearInterval(intervalRef.current);
-                intervalRef.current = null;
-            }
-        };
-    }, [tracking, poll]);
+        return clearPolling;
+    }, [isActive, poll, clearPolling]);
 
     return {
-        tracking,
+        tracking: isActive,
         position,
-        startTracking: () => setTracking(true),
-        stopTracking: () => setTracking(false),
         error,
     };
 }


### PR DESCRIPTION
**What changed

  Added a ref for onTriggered and sync it via an effect. checkPosition now reads the latest callback through
  onTriggeredRef.current() instead of closing over the prop directly, so it can drop onTriggered from its dependency
  list.

  Why it breaks the loop

  Dep chain before:
  - onTriggered (unstable) → checkPosition unstable → poll unstable → main effect re-runs every render → calls poll()
  immediately → setPosition → re-render → repeat

  Dep chain now:
  - onTriggered lives in a ref, not in any useCallback dep list
  - checkPosition deps: [geofenceId, clearPolling] — both stable
  - poll deps: [checkPosition] — stable
  - Main effect deps: [isActive, poll, clearPolling] — only isActive changes when toggled

  The effect now re-runs only when isActive actually flips, which is the intended behavior.**