### PR TITLE
 Persisted the user-selected address on the geofence (DB column + map…

### DIFF
--- a/app/Http/Controllers/GeoFenceController.php
+++ b/app/Http/Controllers/GeoFenceController.php
@@ -30,6 +30,8 @@ class GeoFenceController extends Controller
             'south_lat' => ['required', 'numeric', 'between:-90,90'],
             'east_lng' => ['required', 'numeric', 'between:-180,180'],
             'west_lng' => ['required', 'numeric', 'between:-180,180'],
+            'address_lat' => ['nullable', 'numeric', 'between:-90,90'],
+            'address_lng' => ['nullable', 'numeric', 'between:-180,180'],
         ]);
 
         $geofence = $request->user()->geofence()->create($validated);
@@ -48,6 +50,8 @@ class GeoFenceController extends Controller
             'south_lat' => ['required', 'numeric', 'between:-90,90'],
             'east_lng' => ['required', 'numeric', 'between:-180,180'],
             'west_lng' => ['required', 'numeric', 'between:-180,180'],
+            'address_lat' => ['nullable', 'numeric', 'between:-90,90'],
+            'address_lng' => ['nullable', 'numeric', 'between:-180,180'],
         ]);
 
         $geoFence->update($validated);

--- a/app/Models/GeoFence.php
+++ b/app/Models/GeoFence.php
@@ -18,6 +18,8 @@ class GeoFence extends Model
         'south_lat',
         'east_lng',
         'west_lng',
+        'address_lat',
+        'address_lng',
         'is_active',
     ];
 
@@ -26,6 +28,8 @@ class GeoFence extends Model
         'south_lat' => 'float',
         'east_lng' => 'float',
         'west_lng' => 'float',
+        'address_lat' => 'float',
+        'address_lng' => 'float',
         'is_active' => 'boolean',
     ];
 

--- a/database/migrations/2026_06_16_000000_add_address_to_geo_fences_table.php
+++ b/database/migrations/2026_06_16_000000_add_address_to_geo_fences_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('geo_fences', function (Blueprint $table) {
+            // The address point selected by the user during geofence creation.
+            // Nullable so existing geofences (created before this column existed)
+            // don't break; for new fences it's populated by AddressSearch.
+            $table->decimal('address_lat', 10, 7)->nullable()->after('west_lng');
+            $table->decimal('address_lng', 10, 7)->nullable()->after('address_lat');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('geo_fences', function (Blueprint $table) {
+            $table->dropColumn(['address_lat', 'address_lng']);
+        });
+    }
+};

--- a/resources/js/Components/GeofenceMap.tsx
+++ b/resources/js/Components/GeofenceMap.tsx
@@ -8,6 +8,7 @@ interface GeofenceMapProps {
     geofence: Geofence | null;
     center: [number, number] | null;
     userPosition: [number, number] | null;
+    addressPoint: [number, number] | null;
     onBoundsChange: (bounds: {
         north_lat: number;
         south_lat: number;
@@ -15,6 +16,13 @@ interface GeofenceMapProps {
         west_lng: number;
     }) => void;
 }
+
+const addressIcon = L.divIcon({
+    className: '',
+    html: '<div style="width:22px;height:22px;background:#ef4444;border:3px solid #fff;border-radius:50%;box-shadow:0 2px 6px rgba(0,0,0,0.4);"></div>',
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+});
 
 const cornerIcon = L.divIcon({
     className: '',
@@ -28,6 +36,34 @@ function MapCenter({ center }: { center: [number, number] }) {
     useEffect(() => {
         map.setView(center, 16);
     }, [center, map]);
+    return null;
+}
+
+function AddressMarker({ position }: { position: [number, number] }) {
+    const map = useMap();
+    const markerRef = useRef<L.Marker | null>(null);
+
+    useEffect(() => {
+        if (markerRef.current) {
+            markerRef.current.setLatLng(position);
+        } else {
+            markerRef.current = L.marker(position, {
+                icon: addressIcon,
+                interactive: false,
+                keyboard: false,
+            }).addTo(map);
+        }
+    }, [position, map]);
+
+    useEffect(() => {
+        return () => {
+            if (markerRef.current) {
+                map.removeLayer(markerRef.current);
+                markerRef.current = null;
+            }
+        };
+    }, [map]);
+
     return null;
 }
 
@@ -220,6 +256,7 @@ export default function GeofenceMap({
     geofence,
     center,
     userPosition,
+    addressPoint,
     onBoundsChange,
 }: GeofenceMapProps) {
     const defaultCenter: [number, number] = [29.4241, -98.4936];
@@ -272,6 +309,7 @@ export default function GeofenceMap({
                 bounds={rectBounds}
                 onBoundsChange={onBoundsChange}
             />
+            {addressPoint && <AddressMarker position={addressPoint} />}
             {userPosition && <UserMarker position={userPosition} />}
         </MapContainer>
     );

--- a/resources/js/Components/ScheduleModal.tsx
+++ b/resources/js/Components/ScheduleModal.tsx
@@ -8,6 +8,14 @@ interface ScheduleModalProps {
     onClose: () => void;
 }
 
+const PRESETS = [15, 30, 60, 90, 120, 180];
+const MIN_MINUTES = 1;
+const MAX_MINUTES = 180;
+const STEP = 1;
+
+const clamp = (n: number) =>
+    Math.max(MIN_MINUTES, Math.min(MAX_MINUTES, n));
+
 export default function ScheduleModal({
     distanceMiles,
     estimatedMinutes,
@@ -45,27 +53,75 @@ export default function ScheduleModal({
                     </div>
                 </div>
 
-                <label className="mt-4 block">
-                    <span className="text-sm font-medium text-gray-700">
+                <div className="mt-4">
+                    <span className="block text-sm font-medium text-gray-700">
                         Open garage in (minutes)
                     </span>
-                    <input
-                        type="number"
-                        min={1}
-                        max={180}
-                        value={minutes}
-                        onChange={(e) => {
-                            const v = parseInt(e.target.value, 10);
-                            if (!isNaN(v)) {
-                                setMinutes(Math.max(1, Math.min(180, v)));
-                            }
-                        }}
-                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                    />
-                    <span className="mt-1 block text-xs text-gray-500">
-                        Max 180 minutes (3 hours).
+
+                    <div className="mt-2 flex flex-wrap gap-2">
+                        {PRESETS.map((p) => (
+                            <button
+                                key={p}
+                                type="button"
+                                onClick={() => setMinutes(p)}
+                                className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                                    minutes === p
+                                        ? 'bg-indigo-600 text-white'
+                                        : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                                }`}
+                            >
+                                {p}
+                            </button>
+                        ))}
+                    </div>
+
+                    <div className="mt-3 flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setMinutes(clamp(minutes - STEP))}
+                            disabled={minutes <= MIN_MINUTES}
+                            aria-label="Decrease by 1"
+                            className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-100 text-2xl font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-40"
+                        >
+                            −
+                        </button>
+                        <input
+                            type="text"
+                            inputMode="numeric"
+                            pattern="[0-9]*"
+                            value={minutes}
+                            onChange={(e) => {
+                                const raw = e.target.value.replace(/\D/g, '');
+                                if (raw === '') {
+                                    setMinutes(MIN_MINUTES);
+                                    return;
+                                }
+                                const v = parseInt(raw, 10);
+                                if (!isNaN(v)) setMinutes(clamp(v));
+                            }}
+                            onBlur={(e) => {
+                                // Snap empty/invalid input back to a valid value
+                                const v = parseInt(e.target.value, 10);
+                                setMinutes(isNaN(v) ? MIN_MINUTES : clamp(v));
+                            }}
+                            className="block h-12 flex-1 rounded-md border-gray-300 text-center text-xl font-semibold tabular-nums shadow-sm focus:border-indigo-500 focus:ring-indigo-500 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setMinutes(clamp(minutes + STEP))}
+                            disabled={minutes >= MAX_MINUTES}
+                            aria-label="Increase by 1"
+                            className="flex h-12 w-12 items-center justify-center rounded-md bg-gray-100 text-2xl font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-40"
+                        >
+                            +
+                        </button>
+                    </div>
+
+                    <span className="mt-2 block text-xs text-gray-500">
+                        Max {MAX_MINUTES} minutes (3 hours). Tap a preset or
+                        type a custom value.
                     </span>
-                </label>
+                </div>
 
                 <p className="mt-4 text-xs text-gray-500">
                     Garage opens when the timer ends. Cancel anytime.

--- a/resources/js/Pages/Geofence/Index.tsx
+++ b/resources/js/Pages/Geofence/Index.tsx
@@ -28,22 +28,33 @@ export default function Index({ geofence }: GeofencePageProps) {
               }
             : null,
     );
+    const [addressPoint, setAddressPoint] = useState<[number, number] | null>(
+        geofence?.address_lat != null && geofence?.address_lng != null
+            ? [geofence.address_lat, geofence.address_lng]
+            : null,
+    );
     const [saving, setSaving] = useState(false);
     const [showMap, setShowMap] = useState(!!geofence);
 
     const handleAddressSelect = (lat: number, lng: number) => {
         setCenter([lat, lng]);
+        setAddressPoint([lat, lng]);
         setShowMap(true);
     };
 
     const handleSave = async () => {
         if (!bounds) return;
+        const payload = {
+            ...bounds,
+            address_lat: addressPoint?.[0] ?? null,
+            address_lng: addressPoint?.[1] ?? null,
+        };
         setSaving(true);
         try {
             if (geofence) {
-                await axios.put(`/geo-fences/${geofence.id}`, bounds);
+                await axios.put(`/geo-fences/${geofence.id}`, payload);
             } else {
-                await axios.post('/geo-fences', bounds);
+                await axios.post('/geo-fences', payload);
             }
             router.reload();
         } catch {
@@ -56,6 +67,13 @@ export default function Index({ geofence }: GeofencePageProps) {
     const handleDelete = async () => {
         if (!geofence) return;
         await axios.delete(`/geo-fences/${geofence.id}`);
+        // Reset local UI state so we land back on the empty/search view after
+        // reload. Inertia preserves component state across reloads, so these
+        // need to be cleared explicitly.
+        setShowMap(false);
+        setBounds(null);
+        setCenter(null);
+        setAddressPoint(null);
         router.reload();
     };
 
@@ -97,6 +115,7 @@ export default function Index({ geofence }: GeofencePageProps) {
                                         geofence={geofence}
                                         center={center}
                                         userPosition={null}
+                                        addressPoint={addressPoint}
                                         onBoundsChange={setBounds}
                                     />
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -34,6 +34,8 @@ export interface Geofence {
     south_lat: number;
     east_lng: number;
     west_lng: number;
+    address_lat: number | null;
+    address_lng: number | null;
     is_active: boolean;
     pending_scheduled_trigger: ScheduledTrigger | null;
 }


### PR DESCRIPTION
Persisted the user-selected address on the geofence (DB column + map marker so the chosen location stays visible across reloads), and reworked the scheduling modal's minutes input —
  preset chips for one-tap common values, big −/+ steppers (by 1), and a numeric-keypad-friendly text field that replaces the awkward chevron spinner.