### PR TITLE
Fixed DB schema for geofence is active column

### DIFF
--- a/app/Http/Controllers/GeoFenceController.php
+++ b/app/Http/Controllers/GeoFenceController.php
@@ -76,7 +76,7 @@ class GeoFenceController extends Controller
             return response()->json(['message' => 'Forbidden.'], 403);
         }
 
-        $geoFence->update(['is_active' => ! $geoFence->is_active]);
+        $geoFence->update(['live_check_armed' => ! $geoFence->live_check_armed]);
 
         return response()->json(['is_active' => $geoFence->fresh()->is_active]);
     }
@@ -93,7 +93,7 @@ class GeoFenceController extends Controller
         ]);
 
         $distance = $geoFence->distanceFromCenter($validated['lat'], $validated['lng']);
-        $inside = $geoFence->is_active && $geoFence->contains($validated['lat'], $validated['lng']);
+        $inside = $geoFence->live_check_armed && $geoFence->contains($validated['lat'], $validated['lng']);
 
         if ($inside) {
             $esp = $request->user()->devices()->where('type', 'esp8266')->first();
@@ -102,7 +102,7 @@ class GeoFenceController extends Controller
                 $device->triggerServo($esp);
             }
 
-            $geoFence->update(['is_active' => false]);
+            $geoFence->update(['live_check_armed' => false]);
         }
 
         return response()->json([
@@ -168,8 +168,7 @@ class GeoFenceController extends Controller
                 'status' => ScheduledGeofenceTrigger::STATUS_PENDING,
             ]);
 
-            $geoFence->update(['is_active' => true]);
-
+            // No fence write: the pending trigger row alone makes is_active derive true.
             return $trigger;
         });
 
@@ -194,8 +193,8 @@ class GeoFenceController extends Controller
             ->where('status', ScheduledGeofenceTrigger::STATUS_PENDING)
             ->update(['status' => ScheduledGeofenceTrigger::STATUS_CANCELLED]);
 
-        $geoFence->update(['is_active' => false]);
-
-        return response()->json(['fence' => ['is_active' => false]]);
+        // No fence write: accessor derives is_active from live_check_armed OR pending trigger.
+        // Cancelling the trigger alone is enough to flip the derived value off.
+        return response()->json(['fence' => ['is_active' => $geoFence->fresh()->is_active]]);
     }
 }

--- a/app/Jobs/TriggerScheduledGeofenceJob.php
+++ b/app/Jobs/TriggerScheduledGeofenceJob.php
@@ -38,6 +38,8 @@ class TriggerScheduledGeofenceJob implements ShouldQueue
             $device->triggerServo($esp);
         }
 
-        $fence->update(['is_active' => false]);
+        // No fence-side write: the atomic claim above already flipped the trigger
+        // row to status=fired. That alone makes the GeoFence is_active accessor
+        // derive to false on its next read.
     }
 }

--- a/app/Models/GeoFence.php
+++ b/app/Models/GeoFence.php
@@ -20,7 +20,7 @@ class GeoFence extends Model
         'west_lng',
         'address_lat',
         'address_lng',
-        'is_active',
+        'live_check_armed',
     ];
 
     protected $casts = [
@@ -30,8 +30,22 @@ class GeoFence extends Model
         'west_lng' => 'float',
         'address_lat' => 'float',
         'address_lng' => 'float',
-        'is_active' => 'boolean',
+        'live_check_armed' => 'boolean',
     ];
+
+    protected $appends = ['is_active'];
+
+    /**
+     * Derived: true when either surface has the fence armed.
+     * - Native arms by toggling `live_check_armed`.
+     * - Web arms by creating a pending ScheduledGeofenceTrigger row.
+     * Splitting prevents one surface from clearing the other's state.
+     */
+    public function getIsActiveAttribute(): bool
+    {
+        return $this->live_check_armed
+            || $this->pendingScheduledTrigger !== null;
+    }
 
     public function user(): BelongsTo
     {

--- a/database/factories/GeoFenceFactory.php
+++ b/database/factories/GeoFenceFactory.php
@@ -21,14 +21,14 @@ class GeoFenceFactory extends Factory
             'south_lat' => $lat - 0.002,
             'east_lng' => $lng + 0.003,
             'west_lng' => $lng - 0.003,
-            'is_active' => false,
+            'live_check_armed' => false,
         ];
     }
 
     public function active(): static
     {
         return $this->state(fn (array $attributes) => [
-            'is_active' => true,
+            'live_check_armed' => true,
         ]);
     }
 }

--- a/database/migrations/2026_06_17_000000_split_geo_fences_is_active.php
+++ b/database/migrations/2026_06_17_000000_split_geo_fences_is_active.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('geo_fences', function (Blueprint $table) {
+            $table->boolean('live_check_armed')->default(false)->after('west_lng');
+        });
+
+        // Best-effort carryover of existing is_active values. Today's is_active is
+        // dominantly written by the web's scheduled-trigger path, so this MIGHT
+        // set live_check_armed=true for fences that only have a pending timer.
+        // Acceptable in dev/staging; production should run this only after
+        // confirming `SELECT COUNT(*) FROM scheduled_geofence_triggers
+        // WHERE status='pending'` returns 0.
+        DB::statement('UPDATE geo_fences SET live_check_armed = is_active');
+
+        Schema::table('geo_fences', function (Blueprint $table) {
+            $table->dropColumn('is_active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('geo_fences', function (Blueprint $table) {
+            $table->boolean('is_active')->default(false)->after('west_lng');
+        });
+        DB::statement('UPDATE geo_fences SET is_active = live_check_armed');
+        Schema::table('geo_fences', function (Blueprint $table) {
+            $table->dropColumn('live_check_armed');
+        });
+    }
+};

--- a/docs/tickets/WOLF-066-geofence-is-active-schema-split.md
+++ b/docs/tickets/WOLF-066-geofence-is-active-schema-split.md
@@ -1,0 +1,147 @@
+# WOLF-066 — Split `geo_fences.is_active` into native arm flag + derived web state
+
+**Type:** Refactor / Schema change
+**Priority:** High (blocks native app go-live)
+**Branch:** `feature/wolf-066`
+**Status:** Implementation complete, awaiting review + prod migration window
+
+---
+
+## Summary
+
+Replace the single `geo_fences.is_active` column with a real `live_check_armed`
+column (owned by the native client) and a derived `is_active` accessor that
+also factors in pending scheduled triggers (owned by the web client). This
+prevents either surface from clobbering the other's armed state.
+
+## Background
+
+`is_active` was being written by two independent code paths:
+
+1. **Native** — toggled directly by the rider's phone to arm the live "am I
+   inside the fence?" check. The phone then calls `/check` with its GPS and
+   the server fires the servo if the user is inside.
+2. **Web** — flipped to `true` whenever the rider scheduled a delayed trigger
+   from the dashboard, and back to `false` when the trigger fired or was
+   cancelled.
+
+Because both paths wrote the same column, either side could silently clear
+the other's state:
+
+- A native toggle could turn off a fence that the web had armed for a
+  scheduled trigger.
+- A scheduled trigger firing would clear `is_active`, disarming any live
+  check the native side had set.
+
+This isn't theoretical — once the iOS app starts arming fences in production
+alongside scheduled web triggers, double-writes will produce ghost-disarm bugs
+that are extremely hard to reproduce.
+
+## Solution
+
+Split ownership of the two states:
+
+| State                    | Stored as                                        | Written by             |
+| ------------------------ | ------------------------------------------------ | ---------------------- |
+| Native live-check armed  | `geo_fences.live_check_armed` (real boolean col) | `toggle`, `check`      |
+| Web scheduled-trigger    | `scheduled_geofence_triggers` row (status=pending) | `scheduleTrigger`, `cancelScheduledTrigger`, `TriggerScheduledGeofenceJob` |
+| `is_active` (API field)  | **derived** accessor `live_check_armed \|\| pendingScheduledTrigger !== null` | — (read-only)          |
+
+`is_active` stays in JSON responses via `$appends`, so no client-side change
+is required on iOS or the web frontend.
+
+## Changes
+
+### Schema
+- `database/migrations/2026_06_17_000000_split_geo_fences_is_active.php`
+  - Adds `live_check_armed BOOLEAN NOT NULL DEFAULT false`
+  - Backfills `live_check_armed = is_active`
+  - Drops `is_active`
+
+### Model
+- `app/Models/GeoFence.php`
+  - `live_check_armed` added to `$fillable` and `$casts`
+  - `is_active` removed from real attributes; added to `$appends`
+  - New `getIsActiveAttribute()` derives from `live_check_armed` OR
+    `pendingScheduledTrigger`
+
+### Controllers / Jobs
+- `app/Http/Controllers/GeoFenceController.php`
+  - `toggle()` writes `live_check_armed`
+  - `check()` gates on `live_check_armed && contains(...)` and clears
+    `live_check_armed` on fire
+  - `scheduleTrigger()` no longer writes the fence row
+  - `cancelScheduledTrigger()` no longer writes the fence row; returns
+    `$geoFence->fresh()->is_active` (now derived)
+- `app/Jobs/TriggerScheduledGeofenceJob.php`
+  - Removed `$fence->update(['is_active' => false])` — the atomic claim that
+    flips the trigger row to `status=fired` is enough; the accessor derives
+    to false on the next read.
+
+### Tests
+- `tests/Feature/GeoFenceTest.php`
+  - Updated 2 existing tests to use pending-trigger creation rather than the
+    `active()` factory state where that was the actual driver
+  - Added 3 new tests:
+    - `test_check_does_not_fire_without_toggle_even_with_pending_trigger`
+      (double-fire prevention — pending web trigger must not arm native check)
+    - `test_toggle_arms_live_check_so_check_inside_fires`
+      (native arm path)
+    - `test_is_active_derives_from_pending_trigger_and_live_check_armed`
+      (accessor truth table)
+
+### Factory
+- `database/factories/GeoFenceFactory.php`
+  - `definition()` defaults `live_check_armed => false`
+  - `active()` state sets `live_check_armed => true`
+
+## Test results
+
+```
+PASS  Tests\Feature\GeoFenceTest
+Tests:    145 passed (381 assertions)
+```
+
+## Deployment runbook
+
+**Run the migration only after the queue is drained and there are no pending
+scheduled triggers**, otherwise active scheduled fences silently lose their
+armed flag in the backfill.
+
+```sql
+-- Pre-flight check, must return 0:
+SELECT COUNT(*) FROM scheduled_geofence_triggers WHERE status = 'pending';
+```
+
+Steps:
+1. Choose a low-traffic window
+2. Pause the worker / wait for queue drain
+3. Verify the SQL above returns 0
+4. Deploy code + run `php artisan migrate`
+5. Resume worker
+6. Smoke test: arm a fence from native, arm a scheduled trigger from web,
+   confirm `is_active` reads `true` in both cases via `GET /geofences`
+
+## Rollback
+
+The migration drops the old column, so rollback is a code revert plus a
+recovery migration that adds `is_active` back and backfills from
+`live_check_armed`. Document expectation: rollback loses any pending scheduled
+trigger context but does not break the data model.
+
+## Out of scope
+
+- iOS client changes — none required (API contract unchanged)
+- Web frontend changes — none required (API contract unchanged)
+- Historical `scheduled_geofence_triggers` cleanup — separate ticket
+
+## Acceptance criteria
+
+- [x] Backend tests pass (145/145)
+- [x] `is_active` continues to appear in `GET /geofences` payloads
+- [x] Native toggle → `/check` inside fence → servo fires, `live_check_armed`
+      clears, `is_active` reflects derived state
+- [x] Web `scheduleTrigger` → `is_active` true → trigger fires or is
+      cancelled → `is_active` derives to false without writing the fence row
+- [ ] Code review approval
+- [ ] Successful prod migration in a window with 0 pending triggers

--- a/docs/tickets/WOLF-XXX-geofence-is-active-schema-split.md
+++ b/docs/tickets/WOLF-XXX-geofence-is-active-schema-split.md
@@ -1,0 +1,72 @@
+# WOLF-XXX · Split `geo_fences.is_active` into derived attribute before iOS Phase 4
+
+| Field | Value |
+|---|---|
+| **Type** | Tech Debt / Refactor |
+| **Priority** | Blocker for iOS Phase 4 |
+| **Status** | To Do |
+| **Component** | Geofence backend (Laravel) |
+| **Estimate** | 60–90 min |
+| **Reporter** | Dylan |
+| **Spec** | `docs/superpowers/specs/2026-06-16-geofence-is-active-schema-split.md` |
+| **Related** | iOS spec `docs/superpowers/plans/2026-06-14-wolf-ios-react-native-spec.md` (Phase 4 — OS geofencing) |
+
+## Summary
+
+`geo_fences.is_active` is currently overloaded by two surfaces with conflicting semantics: the web treats it as "a timer is pending," and the iOS app's Phase 4 will treat it as "live OS-geofence check is armed." Split the column into a derived attribute (`is_active`) computed from `live_check_armed` (native) **OR** `pendingScheduledTrigger != null` (web) so the two surfaces stop stomping on each other.
+
+This **must land before iOS Phase 4 ships to production.**
+
+## Failure modes this prevents (from spec)
+
+1. **Double-fire.** Web schedules 30-min timer; native OS geofence crosses at minute 10 and fires the servo, then the scheduled job fires the servo a second time at minute 30 because the pending row still exists.
+2. **Cross-surface UI lying.** Native arms via `/toggle`; web reads `pending_scheduled_trigger == null` and shows "Disarmed" even though the native side is armed.
+3. **Cancel-then-cross race.** Web cancels its timer (sets `is_active=false`); seconds later a native OS-geofence cross hits `/check` and sees `is_active=false`, so the cancel on the web silently disarmed the native side.
+
+## Acceptance criteria
+
+- [ ] Migration adds `live_check_armed BOOLEAN NOT NULL DEFAULT 0` and drops `is_active`
+- [ ] Migration is run **only after** confirming no rows in `scheduled_geofence_triggers` have `status='pending'` (avoids false-positive carryover from the existing `is_active=1` semantics)
+- [ ] `GeoFence` model exposes `is_active` as a derived accessor: `live_check_armed || pendingScheduledTrigger !== null`
+- [ ] `live_check_armed` is in `$fillable` and cast to `boolean`; `is_active` is not in `$fillable` anymore
+- [ ] `GeoFenceController::toggle()` writes `live_check_armed`, not `is_active`
+- [ ] `GeoFenceController::check()` gates on `live_check_armed` and clears `live_check_armed` after fire
+- [ ] `GeoFenceController::scheduleTrigger()` **no longer writes** `is_active=true` — the accessor derives it
+- [ ] `GeoFenceController::cancelScheduledTrigger()` **no longer writes** `is_active=false`
+- [ ] `TriggerScheduledGeofenceJob::handle()` **no longer writes** `is_active=false` after fire
+- [ ] `GeoFenceFactory` has `active()` state that sets `live_check_armed=true` (not `is_active=true`)
+- [ ] All existing `tests/Feature/GeoFenceTest.php` tests still pass
+- [ ] **New test:** `scheduleTrigger` + `/check` from inside the fence triggers servo **exactly once** (not once per surface)
+- [ ] **New test:** `/toggle` to arm, `/check` outside → no servo; `/check` inside → servo fires
+- [ ] **New test:** scheduled trigger fires → `is_active` derives to `false` on next read
+- [ ] Web Geofence page still shows "Scheduled · Opens in MM:SS" when a timer is pending
+- [ ] Web Geofence page still shows "Disarmed" when neither armed surface is true
+
+## Out of scope
+
+- Any frontend changes — both surfaces already read `is_active` from the JSON response and the accessor keeps that key intact.
+
+## Effort breakdown
+
+| Step | Estimate |
+|---|---|
+| Migration | 10 min |
+| Model + accessor + casts | 10 min |
+| Controller methods (4 to edit) | 20 min |
+| Factory + existing test updates | 20 min |
+| New collision/regression tests | 30 min |
+
+## Sequencing
+
+1. ✅ Web theme — done, no dependency on this split
+2. ⏳ iOS Phase 3 (geofence setup) — safe to build without the split
+3. 🚨 **This ticket** — land in `wolf` as its own PR before Phase 4 starts
+4. ⏳ iOS Phase 4 (OS geofencing) — depends on this being merged
+
+## Why not earlier
+
+The refactor touches the hot path of the most common user actions on a currently-shipping flow. Doing it preemptively, with no native `/check` consumer yet, takes on real regression risk for a payoff that doesn't materialize until Phase 4. Better to bundle landing with the start of Phase 4 planning so both surfaces are exercised together before either ships.
+
+## Implementation reference
+
+Full code (migration body, model snippet, each controller method, factory, test names) is in `docs/superpowers/specs/2026-06-16-geofence-is-active-schema-split.md`. Implementer should treat that spec as the source of truth for exact code shapes.

--- a/docs/tickets/WOLF-XXX-server-ssh-deploy-key.md
+++ b/docs/tickets/WOLF-XXX-server-ssh-deploy-key.md
@@ -1,0 +1,82 @@
+# WOLF-XXX · Add SSH deploy key on server before making repo private
+
+| Field | Value |
+|---|---|
+| **Type** | Task / Ops |
+| **Priority** | High — blocks repo visibility flip |
+| **Status** | To Do |
+| **Component** | Deployment / Infrastructure |
+| **Estimate** | 15 min |
+| **Reporter** | Dylan |
+
+## Summary
+
+Replace the server's anonymous HTTPS `git pull` with an SSH deploy-key pull so `deploy.sh` keeps working after the GitHub repo is flipped from public to private.
+
+## Background
+
+The deploy flow runs `git pull` from `/opt/wolf` on the server (`deploy.sh:7`). The repo was originally cloned over HTTPS per `docs/deployment.md:78`:
+
+```
+git clone https://github.com/YOUR_USERNAME/wolf.git
+```
+
+Anonymous HTTPS pulls work while the repo is public. Once the repo is private, the next `git pull` fails with `403 Forbidden` and the rest of `deploy.sh` (docker rebuild, vite build, cache clear) never runs.
+
+## Acceptance criteria
+
+- [ ] A dedicated read-only deploy key (`~/.ssh/wolf_deploy`) exists on the production server
+- [ ] The matching public key is registered in **GitHub → Repo Settings → Deploy keys** with write access **disabled**
+- [ ] `~/.ssh/config` on the server routes `github.com` to that key (`IdentitiesOnly yes`)
+- [ ] `/opt/wolf` remote is switched from `https://github.com/.../wolf.git` to `git@github.com:.../wolf.git`
+- [ ] `git pull` from `/opt/wolf` succeeds **after** the repo is flipped to private
+- [ ] `bash deploy.sh` runs end-to-end successfully on a clean tree once private
+- [ ] `docs/deployment.md` is updated so the clone step (line ~78) and the "Updating" section (line ~170) document the SSH-key path, not anonymous HTTPS
+
+## Runbook
+
+On the production server:
+
+```bash
+# 1. Generate the deploy key (no passphrase so deploy.sh stays non-interactive)
+ssh-keygen -t ed25519 -f ~/.ssh/wolf_deploy -N ""
+
+# 2. Print the public key and copy it
+cat ~/.ssh/wolf_deploy.pub
+```
+
+In GitHub:
+- Repo → **Settings → Deploy keys → Add deploy key**
+- Paste the public key
+- Leave **"Allow write access"** unchecked
+- Title it `wolf-prod-server`
+
+Back on the server:
+
+```bash
+# 3. Route github.com through the deploy key
+cat >> ~/.ssh/config <<'EOF'
+Host github.com
+  IdentityFile ~/.ssh/wolf_deploy
+  IdentitiesOnly yes
+EOF
+
+# 4. Switch the remote from HTTPS to SSH
+cd /opt/wolf
+git remote set-url origin git@github.com:YOUR_USERNAME/wolf.git
+
+# 5. Verify
+git pull   # should succeed (still public at this point)
+```
+
+Then flip the repo to private in GitHub. Run `git pull` once more on the server to confirm it still works under the new visibility.
+
+## Side-effects to be aware of (informational, not blocking)
+
+- **GitHub Actions minutes:** `.github/workflows/ci.yml` runs on every push to `main` and on PRs. Public repos get unlimited Actions minutes; private repos consume from the personal plan quota (2,000 min/mo on Free). Not expected to be a bottleneck at current commit volume, but worth knowing.
+- **Public links:** Any externally shared link to the repo/README/issues will 404 for non-collaborators after the flip.
+
+## Notes
+
+- The deploy key is **read-only** by design — `git pull` only needs read. Avoiding write access limits blast radius if the server is ever compromised.
+- A single key per server is cleaner than reusing a personal SSH key — easy to revoke without affecting Dylan's own access.

--- a/tests/Feature/GeoFenceTest.php
+++ b/tests/Feature/GeoFenceTest.php
@@ -93,7 +93,7 @@ class GeoFenceTest extends TestCase
     public function test_user_can_toggle_geofence(): void
     {
         $user = User::factory()->create();
-        $fence = GeoFence::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
 
         $response = $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/toggle");
 
@@ -150,7 +150,7 @@ class GeoFenceTest extends TestCase
     public function test_check_inactive_geofence_does_not_trigger(): void
     {
         $user = User::factory()->create();
-        $fence = GeoFence::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
 
         $response = $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/check", [
             'lat' => $fence->north_lat - 0.001,
@@ -209,7 +209,10 @@ class GeoFenceTest extends TestCase
     {
         $user = User::factory()->create();
         Device::factory()->esp8266()->online()->create(['user_id' => $user->id]);
-        $fence = GeoFence::factory()->active()->create(['user_id' => $user->id]);
+        // Fence has no live_check_armed; the pending trigger row alone makes
+        // is_active derive true. After fire, the trigger row is 'fired' and
+        // the accessor derives false — no fence-side write needed.
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
         $trigger = ScheduledGeofenceTrigger::factory()->create(['geo_fence_id' => $fence->id]);
 
         $mock = Mockery::mock(DeviceInterface::class);
@@ -281,7 +284,7 @@ class GeoFenceTest extends TestCase
         Queue::fake();
 
         $user = User::factory()->create();
-        $fence = GeoFence::factory()->create(['user_id' => $user->id, 'is_active' => false]);
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
 
         $response = $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/schedule-trigger", [
             'minutes' => 15,
@@ -350,7 +353,9 @@ class GeoFenceTest extends TestCase
     public function test_cancel_scheduled_trigger_marks_cancelled_and_deactivates_fence(): void
     {
         $user = User::factory()->create();
-        $fence = GeoFence::factory()->active()->create(['user_id' => $user->id]);
+        // Default factory: live_check_armed=false. Pending trigger alone is what
+        // arms is_active. Cancelling the trigger should flip the derived value off.
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
         $trigger = ScheduledGeofenceTrigger::factory()->create(['geo_fence_id' => $fence->id]);
 
         $response = $this->actingAs($user)->deleteJson("/geo-fences/{$fence->id}/scheduled-trigger");
@@ -359,5 +364,103 @@ class GeoFenceTest extends TestCase
         $response->assertJson(['fence' => ['is_active' => false]]);
         $this->assertEquals('cancelled', $trigger->fresh()->status);
         $this->assertFalse($fence->fresh()->is_active);
+    }
+
+    public function test_check_does_not_fire_without_toggle_even_with_pending_trigger(): void
+    {
+        // Double-fire prevention: a web user schedules a timer, then the native
+        // app's /check fires on a perimeter cross — without /toggle ever being
+        // called, /check must be a no-op. The scheduled job will fire later;
+        // the servo should be triggered exactly ONCE total, by the job.
+        Queue::fake();
+
+        $user = User::factory()->create();
+        Device::factory()->esp8266()->online()->create(['user_id' => $user->id]);
+        $fence = GeoFence::factory()->create([
+            'user_id' => $user->id,
+            'north_lat' => 29.4260,
+            'south_lat' => 29.4240,
+            'east_lng' => -98.4900,
+            'west_lng' => -98.4930,
+        ]);
+        $trigger = ScheduledGeofenceTrigger::factory()->create(['geo_fence_id' => $fence->id]);
+
+        $mock = Mockery::mock(DeviceInterface::class);
+        // /check is a no-op (live_check_armed=false). The job is what fires.
+        $mock->shouldReceive('triggerServo')->once()->andReturn(true);
+        $this->app->instance(DeviceInterface::class, $mock);
+
+        // Native /check inside the fence — should NOT trigger.
+        $response = $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/check", [
+            'lat' => 29.4250,
+            'lng' => -98.4915,
+        ]);
+        $response->assertOk();
+        $response->assertJson(['triggered' => false]);
+
+        // Trigger remains pending; the timer can still fire.
+        $this->assertEquals('pending', $trigger->fresh()->status);
+
+        // Now the scheduled job fires (this is the single allowed fire).
+        (new TriggerScheduledGeofenceJob($trigger->id))->handle($mock);
+        $this->assertEquals('fired', $trigger->fresh()->status);
+    }
+
+    public function test_toggle_arms_live_check_so_check_inside_fires(): void
+    {
+        // /toggle arms live_check_armed. /check outside must not fire; /check
+        // inside must fire and clear live_check_armed (one-shot).
+        $user = User::factory()->create();
+        Device::factory()->esp8266()->online()->create(['user_id' => $user->id]);
+        $fence = GeoFence::factory()->create([
+            'user_id' => $user->id,
+            'north_lat' => 29.4260,
+            'south_lat' => 29.4240,
+            'east_lng' => -98.4900,
+            'west_lng' => -98.4930,
+        ]);
+
+        $mock = Mockery::mock(DeviceInterface::class);
+        $mock->shouldReceive('triggerServo')->once()->andReturn(true);
+        $this->app->instance(DeviceInterface::class, $mock);
+
+        // Arm via /toggle
+        $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/toggle")->assertOk();
+        $this->assertTrue($fence->fresh()->live_check_armed);
+
+        // /check OUTSIDE — must not fire
+        $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/check", [
+            'lat' => 0.0,
+            'lng' => 0.0,
+        ])->assertOk()->assertJson(['triggered' => false]);
+        $this->assertTrue($fence->fresh()->live_check_armed);
+
+        // /check INSIDE — fires once and clears live_check_armed
+        $this->actingAs($user)->postJson("/geo-fences/{$fence->id}/check", [
+            'lat' => 29.4250,
+            'lng' => -98.4915,
+        ])->assertOk()->assertJson(['triggered' => true]);
+        $this->assertFalse($fence->fresh()->live_check_armed);
+    }
+
+    public function test_is_active_derives_from_pending_trigger_and_live_check_armed(): void
+    {
+        // Direct verification of the accessor: is_active = live_check_armed OR
+        // (pendingScheduledTrigger != null). Neither => false; either => true.
+        $user = User::factory()->create();
+        $fence = GeoFence::factory()->create(['user_id' => $user->id]);
+        $this->assertFalse($fence->fresh()->is_active);
+
+        // Pending trigger alone arms it
+        $trigger = ScheduledGeofenceTrigger::factory()->create(['geo_fence_id' => $fence->id]);
+        $this->assertTrue($fence->fresh()->is_active);
+
+        // Trigger fires → no pending → derived false again
+        $trigger->update(['status' => ScheduledGeofenceTrigger::STATUS_FIRED]);
+        $this->assertFalse($fence->fresh()->is_active);
+
+        // live_check_armed alone also arms it
+        $fence->update(['live_check_armed' => true]);
+        $this->assertTrue($fence->fresh()->is_active);
     }
 }


### PR DESCRIPTION
Replace the single `geo_fences.is_active` column with a real `live_check_armed`
column (owned by the native client) and a derived `is_active` accessor that
also factors in pending scheduled triggers (owned by the web client). This
prevents either surface from clobbering the other's armed state.