### PR TITLE
Add check of "strict type" in php files as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Run Pint
         run: ./vendor/bin/pint --test
 
+      - name: Check declare(strict_types=1) coverage
+        run: composer lint:strict-types
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
         "test": [
             "@php vendor/bin/phpunit --colors=always"
         ],
+        "lint:strict-types": [
+            "bash scripts/check-strict-types.sh"
+        ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"

--- a/docs/tickets/WOLF-116-ci-strict-types-check.md
+++ b/docs/tickets/WOLF-116-ci-strict-types-check.md
@@ -72,22 +72,23 @@ Three additions:
 
 ## Acceptance criteria
 
-- [ ] `scripts/check-strict-types.sh` exists, is executable, and:
+- [x] `scripts/check-strict-types.sh` exists, is executable, and:
   - Exits `0` when every first-party PHP file has
     `declare(strict_types=1);`.
   - Exits `1` with a readable list of offenders otherwise.
   - Correctly excludes `bootstrap/cache/*.php`.
-- [ ] `composer.json` includes a script alias:
-  `"lint:strict-types": "bash scripts/check-strict-types.sh"`.
-- [ ] `.github/workflows/ci.yml`'s `lint` job runs
+- [x] `composer.json` includes a script alias:
+  `"lint:strict-types": ["bash scripts/check-strict-types.sh"]`.
+- [x] `.github/workflows/ci.yml`'s `lint` job runs
   `composer lint:strict-types` after `./vendor/bin/pint --test`.
-- [ ] On the current master (which has WOLF-103 merged),
+- [x] On the current master (which has WOLF-103 merged),
   `composer lint:strict-types` reports **0 offenders** and exits 0.
-- [ ] Manual regression check: temporarily remove the declaration from
-      one file, run `composer lint:strict-types`, verify exit code 1
-      and clear error output. Restore the file.
-- [ ] Existing CI passes end-to-end after the addition (test + lint +
-      build jobs).
+- [x] Manual regression: mutated `app/Models/User.php` to drop the
+      declaration; `composer lint:strict-types` exited **1** and
+      printed `- app/Models/User.php` as the offender with a
+      reproduce hint. File restored; re-check passes.
+- [ ] Existing CI passes end-to-end after the addition (verify on the
+      PR — cannot verify locally).
 
 ## Out of scope
 

--- a/scripts/check-strict-types.sh
+++ b/scripts/check-strict-types.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# WOLF-079 — Enforce declare(strict_types=1); across first-party PHP files.
+#
+# Exits 0 when every scanned file has the declaration; exits 1 with a
+# readable list of offenders otherwise.
+#
+# Scope: app/, tests/, database/, bootstrap/, config/, routes/
+# Excludes: bootstrap/cache/* (framework-generated)
+
+set -euo pipefail
+
+ROOTS=(app tests database bootstrap config routes)
+EXCLUDE_PATH="bootstrap/cache"
+NEEDLE="declare(strict_types=1);"
+
+# Change to repo root regardless of invocation directory.
+cd "$(dirname "$0")/.."
+
+# Collect first-party PHP files, excluding the cache directory.
+missing=$(
+    find "${ROOTS[@]}" -type f -name '*.php' -not -path "${EXCLUDE_PATH}/*" -print0 \
+        | xargs -0 grep -L -- "${NEEDLE}" \
+        || true
+)
+
+if [ -n "${missing}" ]; then
+    echo "Files missing '${NEEDLE}':" >&2
+    echo "${missing}" | sed 's/^/  - /' >&2
+    echo "" >&2
+    echo "Run \`composer lint:strict-types\` locally to reproduce." >&2
+    exit 1
+fi
+
+echo "OK — every first-party PHP file declares strict_types."


### PR DESCRIPTION
WOLF-103 added `declare(strict_types=1);` to every first-party PHP file.
Without a CI guardrail, a new file added tomorrow (or a `make:controller`
scaffold from Artisan, or a `git revert`) can silently drop the
declaration in one file and nobody notices until strict-type coercion
surfaces a bug in production. Add a portable shell check, wire it as a
Composer script for local use, and add a CI step that runs it on every
push and PR.