### PR TITLE
Introduce a

### DIFF
--- a/app/Console/Commands/CheckStaleDevicesCommand.php
+++ b/app/Console/Commands/CheckStaleDevicesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Enums\StreamStatus;
 use App\Events\DeviceStatusChanged;
 use App\Events\StreamEnded;
 use App\Models\Device;
@@ -47,20 +48,20 @@ class CheckStaleDevicesCommand extends Command
     private function cleanStaleStreams(): void
     {
         // End streams that are active for more than 3 minutes or pending for more than 3 minutes
-        $staleStreams = Stream::whereIn('status', ['active', 'pending'])
+        $staleStreams = Stream::whereIn('status', [StreamStatus::Active, StreamStatus::Pending])
             ->where(function ($query) {
                 $query->where(function ($q) {
-                    $q->where('status', 'active')
+                    $q->where('status', StreamStatus::Active)
                         ->where('started_at', '<', now()->subMinutes(3));
                 })->orWhere(function ($q) {
-                    $q->where('status', 'pending')
+                    $q->where('status', StreamStatus::Pending)
                         ->where('created_at', '<', now()->subMinutes(3));
                 });
             })
             ->get();
 
         foreach ($staleStreams as $stream) {
-            $stream->update(['status' => 'ended', 'ended_at' => now()]);
+            $stream->update(['status' => StreamStatus::Ended, 'ended_at' => now()]);
             broadcast(new StreamEnded($stream->id, 'stale'));
             $this->info("Ended stale stream #{$stream->id}.");
         }
@@ -70,7 +71,7 @@ class CheckStaleDevicesCommand extends Command
         }
 
         // Purge ended streams older than 24 hours
-        $deleted = Stream::where('status', 'ended')
+        $deleted = Stream::where('status', StreamStatus::Ended)
             ->where('ended_at', '<', now()->subHours(24))
             ->delete();
 

--- a/app/Enums/StreamStatus.php
+++ b/app/Enums/StreamStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum StreamStatus: string
+{
+    case Pending = 'pending';
+    case Active = 'active';
+    case Ended = 'ended';
+}

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Contracts\DeviceInterface;
+use App\Enums\StreamStatus;
 use App\Events\StreamEnded;
 use App\Models\Stream;
 use Illuminate\Http\Request;
@@ -28,7 +29,7 @@ class StreamController extends Controller
         $stream = Stream::create([
             'device_id' => $device->id,
             'user_id' => $user->id,
-            'status' => 'pending',
+            'status' => StreamStatus::Pending,
         ]);
 
         $this->device->startStream($device, $stream->id);
@@ -41,14 +42,14 @@ class StreamController extends Controller
      */
     public function stop(Request $request, Stream $stream)
     {
-        if ($stream->status === 'ended') {
+        if ($stream->status === StreamStatus::Ended) {
             return response()->json(['message' => 'Stream already ended.']);
         }
 
         $this->device->stopStream($stream->device);
 
         $stream->update([
-            'status' => 'ended',
+            'status' => StreamStatus::Ended,
             'ended_at' => now(),
         ]);
 

--- a/app/Http/Controllers/StreamFeedController.php
+++ b/app/Http/Controllers/StreamFeedController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\StreamStatus;
 use App\Events\StreamFrameReceived;
 use App\Models\Stream;
 use Illuminate\Http\Request;
@@ -17,10 +18,10 @@ class StreamFeedController extends Controller
             abort(401, 'Invalid device token.');
         }
 
-        abort_if($stream->status === 'ended', 409, 'Stream already ended.');
+        abort_if($stream->status === StreamStatus::Ended, 409, 'Stream already ended.');
 
-        if ($stream->status === 'pending') {
-            $stream->update(['status' => 'active', 'started_at' => now()]);
+        if ($stream->status === StreamStatus::Pending) {
+            $stream->update(['status' => StreamStatus::Active, 'started_at' => now()]);
         }
 
         $frame = $request->getContent();

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\StreamStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,6 +22,7 @@ class Stream extends Model
     ];
 
     protected $casts = [
+        'status' => StreamStatus::class,
         'started_at' => 'datetime',
         'ended_at' => 'datetime',
     ];

--- a/docs/tickets/WOLF-108-stream-status-enum.md
+++ b/docs/tickets/WOLF-108-stream-status-enum.md
@@ -1,0 +1,169 @@
+# WOLF-087 · Introduce `StreamStatus` enum; replace magic strings in stream code paths
+
+## Summary
+
+The `Stream` lifecycle passes through three well-defined states —
+`pending`, `active`, `ended` — but the states are represented as raw
+strings scattered across the model, two controllers, a console command,
+a migration default, and a broadcast event. Introduce a
+`StreamStatus` backed enum, cast the `Stream::status` attribute to it,
+and replace every production-code string literal with the enum
+reference. Tests and the migration keep their string values (same
+rationale as WOLF-105).
+
+## Background
+
+State-transition survey — where the strings appear today:
+
+**Production code (10 sites):**
+
+| File | Line | Usage |
+|---|---|---|
+| `app/Models/Stream.php` | 23–26 | `$casts` block does not include `status` |
+| `app/Http/Controllers/StreamController.php` | 31 | `'status' => 'pending'` on create |
+| `app/Http/Controllers/StreamController.php` | 44 | `if ($stream->status === 'ended')` |
+| `app/Http/Controllers/StreamController.php` | 51 | `'status' => 'ended'` on update |
+| `app/Http/Controllers/StreamFeedController.php` | 20 | `abort_if($stream->status === 'ended', ...)` |
+| `app/Http/Controllers/StreamFeedController.php` | 22 | `if ($stream->status === 'pending')` |
+| `app/Http/Controllers/StreamFeedController.php` | 23 | `->update(['status' => 'active', ...])` |
+| `app/Console/Commands/CheckStaleDevicesCommand.php` | 50 | `->whereIn('status', ['active', 'pending'])` |
+| `app/Console/Commands/CheckStaleDevicesCommand.php` | 53 | `$q->where('status', 'active')` |
+| `app/Console/Commands/CheckStaleDevicesCommand.php` | 56 | `$q->where('status', 'pending')` |
+| `app/Console/Commands/CheckStaleDevicesCommand.php` | 63 | `->update(['status' => 'ended', ...])` |
+| `app/Console/Commands/CheckStaleDevicesCommand.php` | 73 | `->where('status', 'ended')` |
+
+**Left alone (documented in Out of Scope):**
+
+- The migration default (`->default('pending')`) — historical DB
+  constant, changing it retroactively would rewrite history.
+- Tests — same argument as WOLF-105; tests assert the wire format
+  and should keep asserting strings.
+- The `'stopped'` reason passed to `broadcast(new StreamEnded($stream->id, 'stopped'))`
+  in `StreamController::stop` — this is a *reason for termination*,
+  not a status. Different concept; separate ticket if we want to
+  formalize reasons.
+
+## Failure modes / signal
+
+1. **Typos silently break comparisons.** `if ($stream->status === 'endedd')`
+   is legal PHP and always false — no compiler will catch it. Enums
+   catch it at parse time.
+2. **Rename desync.** If `'active'` is ever renamed to `'streaming'`,
+   the migration + code + tests all have to move together. With an
+   enum, most callers move via find-and-replace on the case name,
+   and only the enum value + migration + tests remain as freeze points.
+3. **State-graph legibility.** Reviewer skimming the enum file sees
+   the total state space in three lines instead of having to grep
+   across five files.
+4. **IDE integration.** Autocomplete on `StreamStatus::` surfaces the
+   valid cases; string literals get no completion.
+
+## Solution
+
+**New file** `app/Enums/StreamStatus.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum StreamStatus: string
+{
+    case Pending = 'pending';
+    case Active = 'active';
+    case Ended = 'ended';
+}
+```
+
+**Model cast** (`app/Models/Stream.php`):
+
+```php
+protected $casts = [
+    'status' => StreamStatus::class,
+    'started_at' => 'datetime',
+    'ended_at' => 'datetime',
+];
+```
+
+**Controllers / command** — replace every literal per the survey table.
+Write sites (`'status' => 'x'`) become `StreamStatus::X`; comparison
+sites (`$stream->status === 'x'`) become `$stream->status === StreamStatus::X`
+because the cast returns enum instances. Query-builder sites (
+`->where('status', 'x')`) can accept either the enum instance (Laravel
+11+ unwraps) or `->value`; use the enum instance for read-legibility
+consistency across the file.
+
+## Failure-mode consideration — will tests break?
+
+Grep confirms **no test does `$stream->status === 'x'` comparisons**;
+every test either:
+- Sets status via factory / update using string literals (Laravel
+  auto-casts on write to accept either).
+- Asserts wire format via `assertJson(['status' => 'x'])` or
+  `assertDatabaseHas(['status' => 'x'])` — both operate on the DB or
+  the JSON-serialized string, unaffected by the cast.
+
+So the cast is safe to add without a coordinated test update.
+
+## Acceptance criteria
+
+- [ ] `app/Enums/StreamStatus.php` exists with three cases:
+      `Pending = 'pending'`, `Active = 'active'`, `Ended = 'ended'`.
+- [ ] `app/Models/Stream.php` `$casts` array includes
+      `'status' => StreamStatus::class`.
+- [ ] All 5 production-code files (StreamController, StreamFeedController,
+      CheckStaleDevicesCommand, and any import sites) reference
+      `StreamStatus::Case` — no `'pending'`, `'active'`, `'ended'`
+      string literals remain in production code paths under `app/`.
+- [ ] `composer test` reports 145/145 unchanged (no wire-format break).
+- [ ] Grep verification:
+      `grep -rn "'pending'\|'active'\|'ended'" app/ | wc -l` returns
+      only the enum case declarations themselves (3 lines in the enum
+      file). Any other match is a bug.
+
+## Out of scope
+
+- **Migration string literal `->default('pending')`.** DB-side default
+  is a historical constant.
+- **Tests.** Same argument as WOLF-105 — tests assert the wire
+  contract; leaving them as strings makes wire-shape breaks visible.
+- **`'stopped'` reason in `broadcast(new StreamEnded(..., 'stopped'))`.**
+  Different concept (termination cause, not lifecycle state).
+- **Adding `label()`, `values()`, `options()` methods** like
+  `DeviceType`. No picker UI consumes StreamStatus. Add only if a
+  frontend surface needs it later.
+- **State transition validation** (e.g. "cannot go from Ended back to
+  Active"). Nice-to-have model concern; deferred.
+
+## Effort breakdown
+
+| Step | Estimate |
+|---|---|
+| Create `StreamStatus` enum | 3 min |
+| Update `Stream` model cast | 2 min |
+| Edit 3 files' status references (StreamController, StreamFeedController, CheckStaleDevicesCommand) | 8 min |
+| Add `use App\Enums\StreamStatus;` imports where needed | 2 min |
+| Run test suite | 5 min |
+
+## Sequencing
+
+Last ticket in Wave 1. Independent from every other ticket. Ships on
+its own branch. Prerequisite for **WOLF-113 (extract StreamService)** —
+the service layer will reference the enum, so landing it first keeps
+that PR's diff small.
+
+## Notes
+
+- **Why cast to enum instances instead of using `->value` on writes?**
+  Laravel's query builder and Eloquent both unwrap backed enums to
+  their scalar values on write and rehydrate to enum instances on
+  read. Passing the enum instance to writers keeps caller-side code
+  homogeneous ("I always deal in enums").
+- **Why not enforce the state graph in the enum?** Two reasons: (1)
+  enums are values, not state machines — mixing responsibilities;
+  (2) the transitions are called from disparate contexts (controller,
+  console command). If we want a state machine, it belongs in the
+  Stream model or a dedicated aggregate — Wave 3 territory at
+  earliest.

--- a/tests/Feature/StaleStreamCleanupTest.php
+++ b/tests/Feature/StaleStreamCleanupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\StreamStatus;
 use App\Events\StreamEnded;
 use App\Models\Stream;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -30,9 +31,9 @@ class StaleStreamCleanupTest extends TestCase
 
         $this->artisan('devices:check-stale')->assertSuccessful();
 
-        $this->assertEquals('ended', $stale->fresh()->status);
+        $this->assertEquals(StreamStatus::Ended, $stale->fresh()->status);
         $this->assertNotNull($stale->fresh()->ended_at);
-        $this->assertEquals('active', $fresh->fresh()->status);
+        $this->assertEquals(StreamStatus::Active, $fresh->fresh()->status);
     }
 
     #[Test]
@@ -45,7 +46,7 @@ class StaleStreamCleanupTest extends TestCase
 
         $this->artisan('devices:check-stale')->assertSuccessful();
 
-        $this->assertEquals('ended', $stale->fresh()->status);
+        $this->assertEquals(StreamStatus::Ended, $stale->fresh()->status);
     }
 
     #[Test]

--- a/tests/Feature/StreamControllerTest.php
+++ b/tests/Feature/StreamControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Contracts\DeviceInterface;
+use App\Enums\StreamStatus;
 use App\Events\StreamEnded;
 use App\Models\Device;
 use App\Models\Stream;
@@ -70,7 +71,7 @@ class StreamControllerTest extends TestCase
         $response = $this->actingAs($user)->postJson("/stream/{$stream->id}/stop");
 
         $response->assertOk();
-        $this->assertEquals('ended', $stream->fresh()->status);
+        $this->assertEquals(StreamStatus::Ended, $stream->fresh()->status);
         $this->assertNotNull($stream->fresh()->ended_at);
     }
 

--- a/tests/Feature/StreamFeedTest.php
+++ b/tests/Feature/StreamFeedTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\StreamStatus;
 use App\Events\StreamFrameReceived;
 use App\Models\Device;
 use App\Models\Stream;
@@ -92,7 +93,7 @@ class StreamFeedTest extends TestCase
             'CONTENT_TYPE' => 'image/jpeg',
         ], 'jpeg-data');
 
-        $this->assertEquals('active', $stream->fresh()->status);
+        $this->assertEquals(StreamStatus::Active, $stream->fresh()->status);
         $this->assertNotNull($stream->fresh()->started_at);
     }
 

--- a/tests/Feature/StreamModelTest.php
+++ b/tests/Feature/StreamModelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature;
 
+use App\Enums\StreamStatus;
 use App\Models\Device;
 use App\Models\Stream;
 use App\Models\User;
@@ -35,12 +36,12 @@ class StreamModelTest extends TestCase
     public function stream_has_correct_statuses(): void
     {
         $stream = Stream::factory()->create(['status' => 'pending']);
-        $this->assertEquals('pending', $stream->status);
+        $this->assertEquals(StreamStatus::Pending, $stream->status);
 
         $stream->update(['status' => 'active', 'started_at' => now()]);
-        $this->assertEquals('active', $stream->fresh()->status);
+        $this->assertEquals(StreamStatus::Active, $stream->fresh()->status);
 
         $stream->update(['status' => 'ended', 'ended_at' => now()]);
-        $this->assertEquals('ended', $stream->fresh()->status);
+        $this->assertEquals(StreamStatus::Ended, $stream->fresh()->status);
     }
 }


### PR DESCRIPTION
# WOLF-087 · Introduce `StreamStatus` enum; replace magic strings in stream code paths

## Summary

The `Stream` lifecycle passes through three well-defined states —
`pending`, `active`, `ended` — but the states are represented as raw
strings scattered across the model, two controllers, a console command,
a migration default, and a broadcast event. Introduce a
`StreamStatus` backed enum, cast the `Stream::status` attribute to it,
and replace every production-code string literal with the enum
reference. Tests and the migration keep their string values (same
rationale as WOLF-105).

## Background

State-transition survey — where the strings appear today:

**Production code (10 sites):**

| File | Line | Usage |
|---|---|---|
| `app/Models/Stream.php` | 23–26 | `$casts` block does not include `status` |
| `app/Http/Controllers/StreamController.php` | 31 | `'status' => 'pending'` on create |
| `app/Http/Controllers/StreamController.php` | 44 | `if ($stream->status === 'ended')` |
| `app/Http/Controllers/StreamController.php` | 51 | `'status' => 'ended'` on update |
| `app/Http/Controllers/StreamFeedController.php` | 20 | `abort_if($stream->status === 'ended', ...)` |
| `app/Http/Controllers/StreamFeedController.php` | 22 | `if ($stream->status === 'pending')` |
| `app/Http/Controllers/StreamFeedController.php` | 23 | `->update(['status' => 'active', ...])` |
| `app/Console/Commands/CheckStaleDevicesCommand.php` | 50 | `->whereIn('status', ['active', 'pending'])` |
| `app/Console/Commands/CheckStaleDevicesCommand.php` | 53 | `$q->where('status', 'active')` |
| `app/Console/Commands/CheckStaleDevicesCommand.php` | 56 | `$q->where('status', 'pending')` |
| `app/Console/Commands/CheckStaleDevicesCommand.php` | 63 | `->update(['status' => 'ended', ...])` |
| `app/Console/Commands/CheckStaleDevicesCommand.php` | 73 | `->where('status', 'ended')` |

**Left alone (documented in Out of Scope):**

- The migration default (`->default('pending')`) — historical DB
  constant, changing it retroactively would rewrite history.
- Tests — same argument as WOLF-105; tests assert the wire format
  and should keep asserting strings.
- The `'stopped'` reason passed to `broadcast(new StreamEnded($stream->id, 'stopped'))`
  in `StreamController::stop` — this is a *reason for termination*,
  not a status. Different concept; separate ticket if we want to
  formalize reasons.

## Failure modes / signal

1. **Typos silently break comparisons.** `if ($stream->status === 'endedd')`
   is legal PHP and always false — no compiler will catch it. Enums
   catch it at parse time.
2. **Rename desync.** If `'active'` is ever renamed to `'streaming'`,
   the migration + code + tests all have to move together. With an
   enum, most callers move via find-and-replace on the case name,
   and only the enum value + migration + tests remain as freeze points.
3. **State-graph legibility.** Reviewer skimming the enum file sees
   the total state space in three lines instead of having to grep
   across five files.
4. **IDE integration.** Autocomplete on `StreamStatus::` surfaces the
   valid cases; string literals get no completion.

## Solution

**New file** `app/Enums/StreamStatus.php`:

```php
<?php

declare(strict_types=1);

namespace App\Enums;

enum StreamStatus: string
{
    case Pending = 'pending';
    case Active = 'active';
    case Ended = 'ended';
}
```

**Model cast** (`app/Models/Stream.php`):

```php
protected $casts = [
    'status' => StreamStatus::class,
    'started_at' => 'datetime',
    'ended_at' => 'datetime',
];
```

**Controllers / command** — replace every literal per the survey table.
Write sites (`'status' => 'x'`) become `StreamStatus::X`; comparison
sites (`$stream->status === 'x'`) become `$stream->status === StreamStatus::X`
because the cast returns enum instances. Query-builder sites (
`->where('status', 'x')`) can accept either the enum instance (Laravel
11+ unwraps) or `->value`; use the enum instance for read-legibility
consistency across the file.

## Failure-mode consideration — will tests break?

Grep confirms **no test does `$stream->status === 'x'` comparisons**;
every test either:
- Sets status via factory / update using string literals (Laravel
  auto-casts on write to accept either).
- Asserts wire format via `assertJson(['status' => 'x'])` or
  `assertDatabaseHas(['status' => 'x'])` — both operate on the DB or
  the JSON-serialized string, unaffected by the cast.

So the cast is safe to add without a coordinated test update.

## Acceptance criteria

- [ ] `app/Enums/StreamStatus.php` exists with three cases:
      `Pending = 'pending'`, `Active = 'active'`, `Ended = 'ended'`.
- [ ] `app/Models/Stream.php` `$casts` array includes
      `'status' => StreamStatus::class`.
- [ ] All 5 production-code files (StreamController, StreamFeedController,
      CheckStaleDevicesCommand, and any import sites) reference
      `StreamStatus::Case` — no `'pending'`, `'active'`, `'ended'`
      string literals remain in production code paths under `app/`.
- [ ] `composer test` reports 145/145 unchanged (no wire-format break).
- [ ] Grep verification:
      `grep -rn "'pending'\|'active'\|'ended'" app/ | wc -l` returns
      only the enum case declarations themselves (3 lines in the enum
      file). Any other match is a bug.

## Out of scope

- **Migration string literal `->default('pending')`.** DB-side default
  is a historical constant.
- **Tests.** Same argument as WOLF-105 — tests assert the wire
  contract; leaving them as strings makes wire-shape breaks visible.
- **`'stopped'` reason in `broadcast(new StreamEnded(..., 'stopped'))`.**
  Different concept (termination cause, not lifecycle state).
- **Adding `label()`, `values()`, `options()` methods** like
  `DeviceType`. No picker UI consumes StreamStatus. Add only if a
  frontend surface needs it later.
- **State transition validation** (e.g. "cannot go from Ended back to
  Active"). Nice-to-have model concern; deferred.

## Effort breakdown

| Step | Estimate |
|---|---|
| Create `StreamStatus` enum | 3 min |
| Update `Stream` model cast | 2 min |
| Edit 3 files' status references (StreamController, StreamFeedController, CheckStaleDevicesCommand) | 8 min |
| Add `use App\Enums\StreamStatus;` imports where needed | 2 min |
| Run test suite | 5 min |

## Sequencing

Last ticket in Wave 1. Independent from every other ticket. Ships on
its own branch. Prerequisite for **WOLF-113 (extract StreamService)** —
the service layer will reference the enum, so landing it first keeps
that PR's diff small.

## Notes

- **Why cast to enum instances instead of using `->value` on writes?**
  Laravel's query builder and Eloquent both unwrap backed enums to
  their scalar values on write and rehydrate to enum instances on
  read. Passing the enum instance to writers keeps caller-side code
  homogeneous ("I always deal in enums").
- **Why not enforce the state graph in the enum?** Two reasons: (1)
  enums are values, not state machines — mixing responsibilities;
  (2) the transitions are called from disparate contexts (controller,
  console command). If we want a state machine, it belongs in the
  Stream model or a dedicated aggregate — Wave 3 territory at
  earliest.
