### PR TITLE
Standardized every error response on /api/* routes to JSON 

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -30,5 +31,10 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Force JSON error rendering for the entire /api/* surface,
+        // regardless of the caller's Accept header. Fixes iOS crashes
+        // caused by HTML redirects on token expiry / validation error.
+        $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
+            return $request->is('api/*') || $request->expectsJson();
+        });
     })->create();

--- a/docs/tickets/WOLF-101-normalize-api-error-responses.md
+++ b/docs/tickets/WOLF-101-normalize-api-error-responses.md
@@ -1,28 +1,25 @@
 # WOLF-101 · Normalize API error responses (JSON on `api/*`)
 
-| Field | Value |
-|---|---|
-| **Type** | Bug / API contract |
-| **Priority** | High |
-| **Status** | To Do |
-| **Component** | HTTP error handling / API layer |
-| **Estimate** | 45–60 min |
-| **Reporter** | Dylan |
-| **Spec** | – |
-| **Related** | Section 1 walkthrough; Section 11 (API layer); iOS client at `../../../wolf-ios` |
 
 ## Summary
 
-`bootstrap/app.php`'s `withExceptions()` closure is empty, so every exception
-falls through to Laravel's default renderer. For `web` routes that renders
-HTML (correct). For `api/*` routes the response shape depends on the framework
-default per-exception heuristic — some cases return HTML redirects (e.g.
-`AuthenticationException` → redirect to `/login`), which the iOS client cannot
-consume. Standardize a JSON error envelope for all `api/*` responses.
+`bootstrap/app.php`'s `withExceptions()` closure is empty, so exception
+rendering falls through to Laravel's default heuristic. That heuristic
+picks JSON vs HTML based on the incoming request's `Accept` header and
+XHR flag. A client hitting `api/v1/*` without setting
+`Accept: application/json` today gets HTML redirects (e.g.
+`AuthenticationException` → 302 to `/login`) instead of a parseable
+JSON envelope.
+
+Tell Laravel that **any** request against `api/*` should be treated as
+JSON-shaped, regardless of the `Accept` header, using
+`Exceptions::shouldRenderJsonWhen()`. Laravel's built-in renderers
+already produce the correct JSON shape for every relevant exception —
+they just need `expectsJson()` to return true.
 
 ## Background
 
-In `bootstrap/app.php:30-32`:
+`bootstrap/app.php:32-34`:
 
 ```php
 ->withExceptions(function (Exceptions $exceptions): void {
@@ -30,84 +27,130 @@ In `bootstrap/app.php:30-32`:
 })
 ```
 
-No render/report overrides. Concrete symptoms:
+Concrete failure modes today (pre-ticket):
 
-- `AuthenticationException` on `api/v1/*` returns a 302 redirect to `/login`
-  rather than `401 {"message":"Unauthenticated."}`.
-- `ValidationException` on `api/*` returns a mix of shapes depending on the
-  `Accept` header rather than a guaranteed `{"message":..., "errors":{...}}`.
-- `ModelNotFoundException` (route model binding miss) returns generic HTML
-  404 rather than `{"message":"Not found."}`.
-- `ThrottleRequestsException` (after WOLF-100 lands) will inherit whatever the
-  default is unless we standardize now.
+1. **Sanctum token expired mid-session.** iOS hits `api/v1/devices`
+   without a fresh `Accept: application/json` header (or the request
+   drops it mid-retry). Laravel's `AuthenticationException::render()`
+   sees `expectsJson() == false`, redirects to
+   `route('login')` → HTML 302. iOS decoder crashes trying to parse
+   HTML as JSON.
+2. **Validation failure on `api/*` POST.** Returns 422 JSON *if*
+   `Accept` is set. If not, returns HTML form-error page.
+3. **Route model binding miss.** `api/v1/geo-fences/{geoFence}` with
+   a missing ID → `ModelNotFoundException` → 404 HTML page.
+4. **`ThrottleRequestsException`** (WOLF-100 will start returning
+   these) — currently no consistent JSON shape defined.
 
-The iOS client parses JSON error envelopes exclusively. Non-JSON responses
-crash its decoder before the human-readable error can be surfaced.
+## Chosen approach: `shouldRenderJsonWhen()`
+
+One line inside `withExceptions()` gates Laravel's entire renderer
+pipeline into JSON mode for `api/*` requests:
+
+```php
+->withExceptions(function (Exceptions $exceptions): void {
+    $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
+        return $request->is('api/*') || $request->expectsJson();
+    });
+})
+```
+
+Effect:
+
+| Exception | Response (before) | Response (after) |
+|---|---|---|
+| `AuthenticationException` | 302 → `/login` (HTML) | `401 {"message":"Unauthenticated."}` |
+| `AuthorizationException` | Varies | `403 {"message":"This action is unauthorized."}` |
+| `ValidationException` | Depends on `Accept` | `422 {"message":..., "errors":{...}}` |
+| `NotFoundHttpException` / `ModelNotFoundException` | HTML 404 page | `404 {"message":"..."}` |
+| `ThrottleRequestsException` | Depends on `Accept` | `429 {"message":"Too Many Requests"}` + `Retry-After` header |
+
+## Why this approach vs per-exception render closures
+
+Considered but rejected: writing an individual `->render(function
+(AuthenticationException $e, Request $request) {...})` for each of
+the five exception types.
+
+- **Per-exception closures:** ~40 lines, each with its own status,
+  message string, and JSON shape. Every future exception type needs
+  its own closure to get JSON behavior. Message strings duplicated
+  from Laravel's own defaults.
+- **`shouldRenderJsonWhen`:** 5 lines. Zero maintenance for future
+  exception types — Laravel's defaults cover them. Uses Laravel's
+  own message strings (which are localized and match framework
+  documentation).
+
+The tradeoff we accept: Laravel's default messages verbatim.
+
+- `AuthorizationException` → `"This action is unauthorized."`
+  (not `"Forbidden."`)
+- `NotFoundHttpException` → `"The route ... could not be found."`
+  (verbose)
+
+If a specific message needs customizing, a targeted `->render()`
+closure can be added on top of the base rule without changing the
+architecture.
 
 ## Failure modes this prevents
 
-1. **iOS crash on session expiry.** Sanctum token expires mid-session; iOS hits
-   `api/v1/devices`; server returns HTML `/login` redirect; decoder crashes.
-2. **Ambiguous validation surfacing.** iOS form controllers can't reliably
-   discover `errors.<field>` shape and fall back to a generic "Something went
-   wrong" message.
-3. **No structured 429 to back off from.** Post-WOLF-100 the rate limiter fires
-   but the iOS client has no consistent envelope to read `Retry-After` from.
+1. **iOS crash on Accept-header omission.** Any request to `api/*`
+   returns JSON regardless of headers.
+2. **Ambiguous validation surfacing.** iOS form controllers can rely
+   on the `{message, errors}` shape being present for every 422.
+3. **429 shape defined before WOLF-100 lands.** Prerequisite for the
+   rate-limiter ticket.
 
 ## Acceptance criteria
 
-- [ ] `withExceptions()` closure adds render overrides for at least:
-  - `AuthenticationException` → JSON 401 `{"message":"Unauthenticated."}` when
-    `$request->is('api/*')` or `$request->expectsJson()`.
-  - `AuthorizationException` → JSON 403 `{"message":"Forbidden."}` under same
-    condition.
-  - `ValidationException` → JSON 422 with the standard `{message, errors}`
-    envelope (Laravel default is already close; guarantee it applies for
-    `api/*`).
-  - `ModelNotFoundException` and `NotFoundHttpException` → JSON 404
-    `{"message":"Not found."}`.
-  - `ThrottleRequestsException` → JSON 429 with a `Retry-After` header and
-    `{"message":"Too many requests.","retry_after":N}` body.
-- [ ] All existing web-route error behavior is preserved (Inertia flows still
-      redirect / render Blade as before). Guardrail: run existing feature
-      tests unmodified — they must pass.
-- [ ] New tests in `tests/Feature/Api/ErrorShapeTest.php`:
-  - Unauthenticated hit on an `api/v1/*` route returns `401 JSON`, not `302`.
-  - Validation failure on an `api/*` POST returns `422 JSON` matching the
-    `{message, errors}` shape.
-  - Non-existent model on route-model-bound `api/*` route returns `404 JSON`.
-- [ ] `docs/tickets/WOLF-100-apply-device-capture-throttle.md`'s 429 tests are
-      updated to also assert JSON body shape (once this ticket lands).
+- [ ] `bootstrap/app.php`'s `withExceptions()` calls
+      `$exceptions->shouldRenderJsonWhen(...)` with the predicate
+      shown above.
+- [ ] New file `tests/Feature/Api/ErrorShapeTest.php` covers:
+  - Unauthenticated GET on `api/v1/auth/user` (Sanctum-protected)
+    returns `401` with a JSON body containing `message`.
+  - POST on `api/v1/auth/register` with a missing required field
+    returns `422` with a JSON body containing both `message` and
+    `errors.<field>`.
+  - GET on a non-existent nested resource (e.g. `/api/v1/geo-fences/999999`
+    hit as an authenticated user) returns `404` with a JSON body
+    containing `message`.
+- [ ] All 3 tests explicitly omit `Accept: application/json` — the
+      whole point is to prove the change works for clients that
+      don't set it.
+- [ ] `composer test` reports 145+3 = **148 tests** all passing.
+- [ ] Existing web-route tests unmodified — no regression on Inertia
+      flows. Sanity check: `AuthenticationTest`, `ProfileTest`,
+      `DeviceManagementTest` still green.
 
 ## Out of scope
 
-- **Structuring error codes beyond `message`/`errors`.** Adding stable
-  machine-readable `code` strings per exception is nice-to-have and belongs in
-  a follow-up once iOS surface tells us which codes are worth branching on.
-- **Reporting overrides** (e.g. Sentry integration). Reporting is a Section 15
-  concern; this ticket only touches rendering.
-- **Changing `web` route behavior.** Inertia already handles its own error UX
-  via session flashes and 419 CSRF-refresh; do not regress that path.
+- **Adding a machine-readable `code` field** to error responses
+  (e.g. `{"code": "auth.token.expired"}`). Defensible but the iOS
+  client doesn't need it today.
+- **Sentry / reporting overrides.** Rendering only.
+- **`Retry-After` semantic changes.** WOLF-100 will exercise the
+  429 shape; this ticket defines the envelope.
+- **Web-route error UX** stays untouched — Inertia's own error
+  flows continue to work.
 
 ## Effort breakdown
 
 | Step | Estimate |
 |---|---|
-| Write the render closures in `bootstrap/app.php` | 20 min |
-| Add feature tests for each exception → JSON | 25 min |
-| Verify no regression on Inertia web flows (`AuthenticationTest`, `ProfileTest`) | 10 min |
+| Edit `bootstrap/app.php` (~5 lines) | 5 min |
+| Write `tests/Feature/Api/ErrorShapeTest.php` (3 tests) | 15 min |
+| Run test suite, verify no regressions | 10 min |
 
 ## Sequencing
 
-Depends on nothing. Should merge **before** WOLF-100 so the 429 shape is defined
-before we start returning 429s.
+First ticket in Wave 4. **Blocks WOLF-100** — the throttle ticket
+needs a defined 429 shape before it starts returning 429s.
 
 ## Notes
 
-- Prefer `$request->is('api/*') || $request->expectsJson()` as the JSON gate;
-  matches how Laravel itself decides between HTML and JSON.
-- Consider whether to include a stable `type` field (e.g. `type: "authentication"`)
-  in the envelope for iOS to branch on. Deferred to out-of-scope pending iOS input.
-- Extract the render closures into `app/Exceptions/Handlers.php` if the
-  closure gets over ~60 lines — otherwise keep it inline in `bootstrap/app.php`
-  to preserve the Laravel 11+ "no god-kernel" pattern.
+- **Predicate ordering:** `$request->is('api/*')` first (cheaper,
+  more common branch), then `expectsJson()` for the fallback.
+- **Rollback:** trivial — delete the `shouldRenderJsonWhen()` call.
+- **Framework version safety:** `shouldRenderJsonWhen()` is a
+  Laravel 11+ API and this project runs Laravel 13, so the method
+  is available.

--- a/tests/Feature/Api/ErrorShapeTest.php
+++ b/tests/Feature/Api/ErrorShapeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ErrorShapeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * These tests deliberately use bare `->get()` / `->post()` rather than
+     * `->getJson()` / `->postJson()` — omitting `Accept: application/json`
+     * is the whole point. If they still return JSON, `shouldRenderJsonWhen()`
+     * is doing its job.
+     */
+    #[Test]
+    public function unauthenticated_api_request_returns_401_json_without_accept_header(): void
+    {
+        $response = $this->get('/api/v1/auth/user');
+
+        $response->assertStatus(401);
+        $response->assertJsonStructure(['message']);
+    }
+
+    #[Test]
+    public function validation_failure_on_api_route_returns_422_json_without_accept_header(): void
+    {
+        // POST to register with an empty body — required fields missing.
+        $response = $this->post('/api/v1/auth/register', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure(['message', 'errors']);
+    }
+
+    #[Test]
+    public function not_found_route_on_api_surface_returns_404_json_without_accept_header(): void
+    {
+        $response = $this->get('/api/v1/this-route-does-not-exist');
+
+        $response->assertStatus(404);
+        $response->assertJsonStructure(['message']);
+    }
+}


### PR DESCRIPTION
Standardized every error response on /api/* routes to JSON (was previously HTML redirects when clients omitted the Accept: 
  application/json header), using one 5-line shouldRenderJsonWhen() closure in bootstrap/app.php and 3 new tests that prove
  it works without the header.