### PR TITLE
WOLF-102: standardize DEVICE_DRIVER on esp32_mqtt

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -65,7 +65,7 @@ REDIS_PORT=6379
 
 # --- MQTT ---
 # Mosquitto runs inside Docker. ESP devices connect on port 1883.
-DEVICE_DRIVER=mqtt
+DEVICE_DRIVER=esp32_mqtt
 MQTT_HOST=mosquitto
 MQTT_PORT=1883
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->singleton(DeviceInterface::class, function () {
             return match (config('device.driver')) {
-                'mqtt', 'esp32_mqtt' => new Esp32MqttDevice(
+                'esp32_mqtt' => new Esp32MqttDevice(
                     host: config('device.mqtt.host'),
                     port: config('device.mqtt.port'),
                     username: config('device.mqtt.username'),


### PR DESCRIPTION
The '.env.production.example' template said 'DEVICE_DRIVER=mqtt' while the actual '.env.production' used 'esp32_mqtt'. The AppServiceProvider match accepted both, which papered over the drift — a new operator copying the example would get a working setup by accident, but any future cleanup of the "redundant" case would silently downgrade their production to MockDevice.